### PR TITLE
PROD-347: Support for Oauth Access Tokens

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -45,6 +45,7 @@ func backend() *azureSecretBackend {
 		Paths: framework.PathAppend(
 			pathsRole(&b),
 			[]*framework.Path{
+				pathAccessToken(&b),
 				pathConfig(&b),
 				pathServicePrincipal(&b),
 			},

--- a/backend_test.go
+++ b/backend_test.go
@@ -2,6 +2,8 @@ package azuresecrets
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -13,6 +15,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
+	azureadal "github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
@@ -175,7 +179,8 @@ func (m *mockProvider) UpdateApplicationPasswordCredentials(ctx context.Context,
 func (m *mockProvider) ListApplicationPasswordCredentials(ctx context.Context, applicationObjectID string) (result graphrbac.PasswordCredentialListResult, err error) {
 	var creds []graphrbac.PasswordCredential
 	for keyID := range m.passwords {
-		creds = append(creds, graphrbac.PasswordCredential{KeyID: &keyID})
+		kCopy := keyID
+		creds = append(creds, graphrbac.PasswordCredential{KeyID: &kCopy})
 	}
 
 	return graphrbac.PasswordCredentialListResult{
@@ -230,6 +235,20 @@ func (m *mockProvider) GetGroup(ctx context.Context, objectID string) (result gr
 	}
 
 	return g, nil
+}
+
+func (m *mockProvider) GetToken(c auth.ClientCredentialsConfig) (azureadal.Token, error) {
+	expires := time.Now().Add(1 * time.Minute)
+
+	jwt := []byte(fmt.Sprintf("{\"exp\":%v,\"aud\":\"audience\"}", expires.Unix()))
+	header := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte("header"))
+	payload := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(jwt)
+	signature := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte("signature"))
+	return azureadal.Token{
+		AccessToken: fmt.Sprintf("%v.%v.%v", header, payload, signature),
+		ExpiresIn:   json.Number(fmt.Sprintf("%v", expires.Sub(time.Now()).Truncate(time.Second))),
+		ExpiresOn:   json.Number(fmt.Sprintf("%v", expires.Unix())),
+	}, nil
 }
 
 // ListGroups gets list of groups for the current tenant.

--- a/client.go
+++ b/client.go
@@ -321,6 +321,15 @@ func groupObjectIDs(groups []*AzureGroup) []string {
 	return groupIDs
 }
 
+func roleIDs(roles []*AzureRole) []string {
+	groupIDs := make([]string, 0, len(roles))
+	for _, role := range roles {
+		groupIDs = append(groupIDs, role.RoleID)
+
+	}
+	return groupIDs
+}
+
 // search for roles by name
 func (c *client) findRoles(ctx context.Context, roleName string) ([]authorization.RoleDefinition, error) {
 	return c.provider.ListRoles(ctx, fmt.Sprintf("subscriptions/%s", c.settings.SubscriptionID), fmt.Sprintf("roleName eq '%s'", roleName))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.2
+	github.com/Azure/go-autorest/autorest/adal v0.7.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0

--- a/path_access_token.go
+++ b/path_access_token.go
@@ -55,6 +55,10 @@ func (b *azureSecretBackend) pathAccessTokenRead(ctx context.Context, request *l
 		return logical.ErrorResponse("role '%s' cannot generate access tokens (has secret type %s)", roleName, role.CredentialType), nil
 	}
 
+	if role.Credentials == nil {
+		return logical.ErrorResponse("role '%s' configured before plugin supported access tokens (update or recreate role)", roleName), nil
+	}
+
 	return b.secretAccessTokenResponse(ctx, request.Storage, role)
 }
 

--- a/path_access_token.go
+++ b/path_access_token.go
@@ -1,0 +1,153 @@
+package azuresecrets
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	azureadal "github.com/Azure/go-autorest/autorest/adal"
+	azureauth "github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	azureAppNotFoundErrCode = 700016
+)
+
+func pathAccessToken(b *azureSecretBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("token/%s", framework.GenericNameRegex("role")),
+		Fields: map[string]*framework.FieldSchema{
+			"role": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the Vault role",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathAccessTokenRead,
+			},
+		},
+		HelpSynopsis:    pathAccessTokenHelpSyn,
+		HelpDescription: pathAccessTokenHelpDesc,
+	}
+}
+
+func (b *azureSecretBackend) pathAccessTokenRead(ctx context.Context, request *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := data.Get("role").(string)
+
+	role, err := getRole(ctx, roleName, request.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	if role == nil {
+		return logical.ErrorResponse("role '%s' does not exist", roleName), nil
+	}
+
+	if role.CredentialType != credentialTypeSP {
+		return logical.ErrorResponse("role '%s' cannot generate access tokens (has secret type %s)", roleName, role.CredentialType), nil
+	}
+
+	return b.secretAccessTokenResponse(ctx, request.Storage, role)
+}
+
+func (b *azureSecretBackend) secretAccessTokenResponse(ctx context.Context, storage logical.Storage, role *roleEntry) (*logical.Response, error) {
+	client, err := b.getClient(ctx, storage)
+	if err != nil {
+		return nil, err
+	}
+
+	cc := azureauth.NewClientCredentialsConfig(role.ApplicationID, role.Credentials.Password, client.settings.TenantID)
+	token, err := b.getToken(ctx, client, cc)
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := decodeAccessToken(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	exp := time.Unix(j.Expiration, 0)
+	ttl := math.Max(exp.Sub(now).Truncate(time.Second).Seconds(), 0)
+
+	// access_tokens are not revocable therefore do not return a framework.Secret (i.e. a lease)
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"token":              token.AccessToken,
+			"token_ttl":          ttl,
+			"expires_at_seconds": j.Expiration,
+		},
+	}, nil
+}
+
+func decodeAccessToken(token string) (*jws, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid JWT from Azure")
+	}
+
+	decodedToken, err := base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	j := &jws{}
+	err = json.Unmarshal(decodedToken, j)
+	if err != nil {
+		return nil, err
+	}
+
+	return j, nil
+}
+
+type jws struct {
+	// Expiration is the Epoch when the JWT expires
+	Expiration int64 `json:"exp"`
+}
+
+func (b *azureSecretBackend) getToken(ctx context.Context, client *client, c azureauth.ClientCredentialsConfig) (azureadal.Token, error) {
+	token, err := retry(ctx, func() (interface{}, bool, error) {
+		t, err := client.provider.GetToken(c)
+
+		if hasAzureErrorCode(err, azureAppNotFoundErrCode) {
+			return nil, false, nil
+		} else if err != nil {
+			return nil, true, err
+		}
+
+		return t, true, nil
+	})
+
+	var t azureadal.Token
+	if token != nil {
+		t = token.(azureadal.Token)
+	}
+
+	return t, err
+}
+
+func hasAzureErrorCode(e error, code int) bool {
+	tErr, ok := e.(azureadal.TokenRefreshError)
+
+	// use a pattern match as TokenRefreshError is not easily parsable
+	return ok && tErr != nil && strings.Contains(tErr.Error(), fmt.Sprint(code))
+}
+
+const pathAccessTokenHelpSyn = `
+Request an access token for a given Vault role.
+`
+
+const pathAccessTokenHelpDesc = `
+This path creates access token credentials. The associated role must
+be created ahead of time with either an existing App/Service Principal or 
+else a dynamic Service Principal will be created.
+`

--- a/path_access_token_test.go
+++ b/path_access_token_test.go
@@ -1,0 +1,96 @@
+package azuresecrets
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/logical"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_decodeAccessToken(t *testing.T) {
+	nowEpoch := time.Now().Unix()
+	jwt := []byte(fmt.Sprintf("{\"exp\":%v,\"aud\":\"audience\"}", nowEpoch))
+	encodedJwt := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(jwt)
+	tests := []struct {
+		name    string
+		token   string
+		want    *jws
+		wantErr bool
+	}{
+		{
+			name:    "access token decoded",
+			token:   fmt.Sprintf("header.%v.signature", encodedJwt),
+			want:    &jws{Expiration: nowEpoch},
+			wantErr: false,
+		},
+		{
+			name:    "invalid access token",
+			token:   fmt.Sprintf("header.%v", encodedJwt),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeAccessToken(tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeAccessToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("decodeAccessToken() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_azureSecretBackend_pathAccessTokenRead(t *testing.T) {
+	b, s := getTestBackend(t, true)
+
+	t.Run("token generated", func(t *testing.T) {
+		role := generateUUID()
+		testRoleCreate(t, b, s, role, testStaticSPRole)
+
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "token/" + role,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		if resp.IsError() {
+			t.Fatalf("receive response error: %v", resp.Error())
+		}
+
+		if _, ok := resp.Data["token"]; !ok {
+			t.Fatalf("token not found in response")
+		}
+
+		if _, ok := resp.Data["token_ttl"]; !ok {
+			t.Fatalf("token_ttl not found in response")
+		}
+
+		if _, ok := resp.Data["expires_at_seconds"]; !ok {
+			t.Fatalf("expires_at_seconds not found in response")
+		}
+	})
+
+	t.Run("role does not exist", func(t *testing.T) {
+		role := generateUUID()
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "token/" + role,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		if !resp.IsError() {
+			t.Fatal("expected missing role error")
+		}
+	})
+}

--- a/path_config.go
+++ b/path_config.go
@@ -60,11 +60,19 @@ func pathConfig(b *azureSecretBackend) *framework.Path {
 				Description: "Name of the password policy to use to generate passwords for dynamic credentials.",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   b.pathConfigRead,
-			logical.CreateOperation: b.pathConfigWrite,
-			logical.UpdateOperation: b.pathConfigWrite,
-			logical.DeleteOperation: b.pathConfigDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigRead,
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigWrite,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigWrite,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigDelete,
+			},
 		},
 		ExistenceCheck:  b.pathConfigExistenceCheck,
 		HelpSynopsis:    confHelpSyn,

--- a/path_roles.go
+++ b/path_roles.go
@@ -302,7 +302,8 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 	}
 
 	var r *roleEntry
-	if req.Operation == logical.CreateOperation {
+	// Only add credentials if this is a new role or a role that existed before access token support was available
+	if req.Operation == logical.CreateOperation || role.Credentials == nil {
 		if role.ApplicationType == "static" {
 			r, err = b.createStaticSPSecret(ctx, client, name, role)
 		} else {

--- a/path_roles.go
+++ b/path_roles.go
@@ -82,11 +82,19 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 					Description: "Maximum time a service principal. If not set or set to 0, will use system default.",
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation:   b.pathRoleRead,
-				logical.CreateOperation: b.pathRoleUpdate,
-				logical.UpdateOperation: b.pathRoleUpdate,
-				logical.DeleteOperation: b.pathRoleDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleRead,
+				},
+				logical.CreateOperation: &framework.PathOperation{
+					Callback: b.pathRoleUpdate,
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback: b.pathRoleUpdate,
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback: b.pathRoleDelete,
+				},
 			},
 			HelpSynopsis:    roleHelpSyn,
 			HelpDescription: roleHelpDesc,
@@ -94,8 +102,10 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 		},
 		{
 			Pattern: "roles/?",
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ListOperation: b.pathRoleList,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.pathRoleList,
+				},
 			},
 			HelpSynopsis:    roleListHelpSyn,
 			HelpDescription: roleListHelpDesc,

--- a/path_roles.go
+++ b/path_roles.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
+	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -24,13 +25,21 @@ const (
 
 // roleEntry is a Vault role construct that maps to Azure roles or Applications
 type roleEntry struct {
-	CredentialType      int           `json:"credential_type"` // Reserved. Always SP at this time.
-	AzureRoles          []*AzureRole  `json:"azure_roles"`
-	AzureGroups         []*AzureGroup `json:"azure_groups"`
-	ApplicationID       string        `json:"application_id"`
-	ApplicationObjectID string        `json:"application_object_id"`
-	TTL                 time.Duration `json:"ttl"`
-	MaxTTL              time.Duration `json:"max_ttl"`
+	CredentialType      int                `json:"credential_type"` // Reserved. Always SP at this time.
+	AzureRoles          []*AzureRole       `json:"azure_roles"`
+	AzureGroups         []*AzureGroup      `json:"azure_groups"`
+	ApplicationID       string             `json:"application_id"`
+	ApplicationObjectID string             `json:"application_object_id"`
+	ApplicationType     string             `json:"application_type"`
+	ServicePrincipalID  string             `json:"service_principal_id"`
+	TTL                 time.Duration      `json:"ttl"`
+	MaxTTL              time.Duration      `json:"max_ttl"`
+	Credentials         *ClientCredentials `json:"credentials"`
+}
+
+type ClientCredentials struct {
+	KeyId    string `json:"key_id"`
+	Password string `json:"password"`
 }
 
 // AzureRole is an Azure Role (https://docs.microsoft.com/en-us/azure/role-based-access-control/overview) applied
@@ -142,6 +151,11 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 	// load or create role
 	name := d.Get("name").(string)
+
+	lock := locksutil.LockForKey(b.appLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
+
 	role, err := getRole(ctx, name, req.Storage)
 	if err != nil {
 		return nil, errwrap.Wrapf("error reading role: {{err}}", err)
@@ -184,6 +198,9 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			return nil, errwrap.Wrapf("error loading Application: {{err}}", err)
 		}
 		role.ApplicationID = to.String(app.AppID)
+		role.ApplicationType = "static"
+	} else {
+		role.ApplicationType = "dynamic"
 	}
 
 	// Parse the Azure roles
@@ -284,8 +301,20 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		return logical.ErrorResponse("either Azure role definitions, group definitions, or an Application Object ID must be provided"), nil
 	}
 
+	var r *roleEntry
+	if req.Operation == logical.CreateOperation {
+		if role.ApplicationType == "static" {
+			r, err = b.createStaticSPSecret(ctx, client, name, role)
+		} else {
+			r, err = b.createSPSecret(ctx, client, name, role)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// save role
-	err = saveRole(ctx, req.Storage, role, name)
+	err = saveRole(ctx, req.Storage, r, name)
 	if err != nil {
 		return nil, errwrap.Wrapf("error storing role: {{err}}", err)
 	}
@@ -311,7 +340,11 @@ func (b *azureSecretBackend) pathRoleRead(ctx context.Context, req *logical.Requ
 	data["max_ttl"] = r.MaxTTL / time.Second
 	data["azure_roles"] = r.AzureRoles
 	data["azure_groups"] = r.AzureGroups
-	data["application_object_id"] = r.ApplicationObjectID
+	aoid := ""
+	if r.ApplicationType == "static" {
+		aoid = r.ApplicationObjectID
+	}
+	data["application_object_id"] = aoid
 
 	return &logical.Response{
 		Data: data,
@@ -330,12 +363,37 @@ func (b *azureSecretBackend) pathRoleList(ctx context.Context, req *logical.Requ
 func (b *azureSecretBackend) pathRoleDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
-	err := req.Storage.Delete(ctx, fmt.Sprintf("%s/%s", rolesStoragePath, name))
+	lock := locksutil.LockForKey(b.appLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	role, err := getRole(ctx, name, req.Storage)
+	if err != nil {
+		return nil, errwrap.Wrapf(fmt.Sprintf("unable to get role %s: {{err}}", name), err)
+	}
+	if role == nil {
+		return nil, nil
+	}
+
+	var resp *logical.Response
+	if role.ApplicationType == "static" {
+		resp, err = b.staticSPRemove(ctx, req, role)
+		if err != nil {
+			return &logical.Response{Warnings: []string{"error removing existing Azure app password"}}, nil
+		}
+	} else {
+		resp, err = b.spRemove(ctx, req, role)
+		if err != nil {
+			return &logical.Response{Warnings: []string{"error removing dynamic Azure service principal"}}, nil
+		}
+	}
+
+	err = req.Storage.Delete(ctx, fmt.Sprintf("%s/%s", rolesStoragePath, name))
 	if err != nil {
 		return nil, errwrap.Wrapf("error deleting role: {{err}}", err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (b *azureSecretBackend) pathRoleExistenceCheck(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -46,8 +46,10 @@ func pathServicePrincipal(b *azureSecretBackend) *framework.Path {
 				Description: "Name of the Vault role",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: b.pathSPRead,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathSPRead,
+			},
 		},
 		HelpSynopsis:    pathServicePrincipalHelpSyn,
 		HelpDescription: pathServicePrincipalHelpDesc,

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -74,18 +74,33 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 		return logical.ErrorResponse(fmt.Sprintf("role '%s' does not exist", roleName)), nil
 	}
 
-	var resp *logical.Response
-
-	if role.ApplicationObjectID != "" {
-		resp, err = b.createStaticSPSecret(ctx, client, roleName, role)
+	var r *roleEntry
+	var secretType string
+	if role.ApplicationType == "static" {
+		r, err = b.createStaticSPSecret(ctx, client, roleName, role)
+		secretType = SecretTypeStaticSP
 	} else {
-		resp, err = b.createSPSecret(ctx, client, roleName, role)
+		r, err = b.createSPSecret(ctx, client, roleName, role)
+		secretType = SecretTypeSP
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
+	data := map[string]interface{}{
+		"client_id":     r.ApplicationID,
+		"client_secret": r.Credentials.Password,
+	}
+	internalData := map[string]interface{}{
+		"app_object_id":        r.ApplicationObjectID,
+		"key_id":               r.Credentials.KeyId,
+		"sp_object_id":         r.ServicePrincipalID,
+		"role_assignment_ids":  roleIDs(r.AzureRoles),
+		"group_membership_ids": groupObjectIDs(r.AzureGroups),
+		"role":                 roleName,
+	}
+	resp := b.Secret(secretType).Response(data, internalData)
 	resp.Secret.TTL = role.TTL
 	resp.Secret.MaxTTL = role.MaxTTL
 
@@ -93,7 +108,7 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 }
 
 // createSPSecret generates a new App/Service Principal.
-func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*logical.Response, error) {
+func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*roleEntry, error) {
 	// Create the App, which is the top level object to be tracked in the secret
 	// and deleted upon revocation. If any subsequent step fails, the App is deleted.
 	app, err := c.createApp(ctx)
@@ -111,8 +126,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 	}
 
 	// Assign Azure roles to the new SP
-	raIDs, err := c.assignRoles(ctx, sp, role.AzureRoles)
-	if err != nil {
+	if _, err = c.assignRoles(ctx, sp, role.AzureRoles); err != nil {
 		c.deleteApp(ctx, appObjID)
 		return nil, err
 	}
@@ -123,23 +137,26 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 		return nil, err
 	}
 
-	data := map[string]interface{}{
-		"client_id":     appID,
-		"client_secret": password,
-	}
-	internalData := map[string]interface{}{
-		"app_object_id":        appObjID,
-		"sp_object_id":         sp.ObjectID,
-		"role_assignment_ids":  raIDs,
-		"group_membership_ids": groupObjectIDs(role.AzureGroups),
-		"role":                 roleName,
+	r := &roleEntry{
+		CredentialType:      role.CredentialType,
+		AzureRoles:          role.AzureRoles,
+		AzureGroups:         role.AzureGroups,
+		ApplicationID:       appID,
+		ApplicationObjectID: appObjID,
+		ApplicationType:     role.ApplicationType,
+		ServicePrincipalID:  to.String(sp.ObjectID),
+		TTL:                 role.TTL,
+		MaxTTL:              role.MaxTTL,
+		Credentials: &ClientCredentials{
+			Password: password,
+		},
 	}
 
-	return b.Secret(SecretTypeSP).Response(data, internalData), nil
+	return r, nil
 }
 
 // createStaticSPSecret adds a new password to the App associated with the role.
-func (b *azureSecretBackend) createStaticSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*logical.Response, error) {
+func (b *azureSecretBackend) createStaticSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*roleEntry, error) {
 	lock := locksutil.LockForKey(b.appLocks, role.ApplicationObjectID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -149,17 +166,22 @@ func (b *azureSecretBackend) createStaticSPSecret(ctx context.Context, c *client
 		return nil, err
 	}
 
-	data := map[string]interface{}{
-		"client_id":     role.ApplicationID,
-		"client_secret": password,
-	}
-	internalData := map[string]interface{}{
-		"app_object_id": role.ApplicationObjectID,
-		"key_id":        keyID,
-		"role":          roleName,
+	r := &roleEntry{
+		CredentialType:      role.CredentialType,
+		AzureRoles:          role.AzureRoles,
+		AzureGroups:         role.AzureGroups,
+		ApplicationID:       role.ApplicationID,
+		ApplicationObjectID: role.ApplicationObjectID,
+		ApplicationType:     role.ApplicationType,
+		TTL:                 role.TTL,
+		MaxTTL:              role.MaxTTL,
+		Credentials: &ClientCredentials{
+			KeyId:    keyID,
+			Password: password,
+		},
 	}
 
-	return b.Secret(SecretTypeStaticSP).Response(data, internalData), nil
+	return r, nil
 }
 
 func (b *azureSecretBackend) spRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -185,8 +207,6 @@ func (b *azureSecretBackend) spRenew(ctx context.Context, req *logical.Request, 
 }
 
 func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	resp := new(logical.Response)
-
 	appObjectIDRaw, ok := req.Secret.InternalData["app_object_id"]
 	if !ok {
 		return nil, errors.New("internal data 'app_object_id' not found")
@@ -201,22 +221,38 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 		spObjectID = spObjectIDRaw.(string)
 	}
 
-	var raIDs []string
+	var roles []*AzureRole
 	if req.Secret.InternalData["role_assignment_ids"] != nil {
 		for _, v := range req.Secret.InternalData["role_assignment_ids"].([]interface{}) {
-			raIDs = append(raIDs, v.(string))
+			roles = append(roles, &AzureRole{
+				RoleID: v.(string),
+			})
 		}
 	}
 
-	var gmIDs []string
+	var groups []*AzureGroup
 	if req.Secret.InternalData["group_membership_ids"] != nil {
 		for _, v := range req.Secret.InternalData["group_membership_ids"].([]interface{}) {
-			gmIDs = append(gmIDs, v.(string))
+			groups = append(groups, &AzureGroup{
+				ObjectID: v.(string),
+			})
 		}
 	}
 
-	if len(gmIDs) != 0 && spObjectID == "" {
-		return nil, errors.New("internal data 'sp_object_id' not found")
+	r := &roleEntry{
+		AzureRoles:          roles,
+		AzureGroups:         groups,
+		ApplicationObjectID: appObjectID,
+		ServicePrincipalID:  spObjectID,
+	}
+
+	return b.spRemove(ctx, req, r)
+}
+
+func (b *azureSecretBackend) spRemove(ctx context.Context, req *logical.Request, role *roleEntry) (*logical.Response, error) {
+	resp := new(logical.Response)
+	if len(role.AzureGroups) != 0 && role.ServicePrincipalID == "" {
+		return nil, errors.New("service principal ID not found")
 	}
 
 	c, err := b.getClient(ctx, req.Storage)
@@ -226,18 +262,18 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 
 	// unassigning roles is effectively a garbage collection operation. Errors will be noted but won't fail the
 	// revocation process. Deleting the app, however, *is* required to consider the secret revoked.
-	if err := c.unassignRoles(ctx, raIDs); err != nil {
+	if err := c.unassignRoles(ctx, roleIDs(role.AzureRoles)); err != nil {
 		resp.AddWarning(err.Error())
 	}
 
 	// removing group membership is effectively a garbage collection
 	// operation. Errors will be noted but won't fail the revocation process.
 	// Deleting the app, however, *is* required to consider the secret revoked.
-	if err := c.removeGroupMemberships(ctx, spObjectID, gmIDs); err != nil {
+	if err := c.removeGroupMemberships(ctx, role.ServicePrincipalID, groupObjectIDs(role.AzureGroups)); err != nil {
 		resp.AddWarning(err.Error())
 	}
 
-	err = c.deleteApp(ctx, appObjectID)
+	err = c.deleteApp(ctx, role.ApplicationObjectID)
 
 	return resp, err
 }
@@ -247,13 +283,7 @@ func (b *azureSecretBackend) staticSPRevoke(ctx context.Context, req *logical.Re
 	if !ok {
 		return nil, errors.New("internal data 'app_object_id' not found")
 	}
-
 	appObjectID := appObjectIDRaw.(string)
-
-	c, err := b.getClient(ctx, req.Storage)
-	if err != nil {
-		return nil, errwrap.Wrapf("error during revoke: {{err}}", err)
-	}
 
 	keyIDRaw, ok := req.Secret.InternalData["key_id"]
 	if !ok {
@@ -264,7 +294,23 @@ func (b *azureSecretBackend) staticSPRevoke(ctx context.Context, req *logical.Re
 	lock.Lock()
 	defer lock.Unlock()
 
-	return nil, c.deleteAppPassword(ctx, appObjectID, keyIDRaw.(string))
+	r := &roleEntry{
+		ApplicationObjectID: appObjectID,
+		Credentials: &ClientCredentials{
+			KeyId: keyIDRaw.(string),
+		},
+	}
+
+	return b.staticSPRemove(ctx, req, r)
+}
+
+func (b *azureSecretBackend) staticSPRemove(ctx context.Context, req *logical.Request, role *roleEntry) (*logical.Response, error) {
+	c, err := b.getClient(ctx, req.Storage)
+	if err != nil {
+		return nil, errwrap.Wrapf("error during revoke: {{err}}", err)
+	}
+
+	return nil, c.deleteAppPassword(ctx, role.ApplicationObjectID, role.Credentials.KeyId)
 }
 
 const pathServicePrincipalHelpSyn = `

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -226,9 +226,9 @@ func TestStaticSPRead(t *testing.T) {
 }
 
 func TestSPRevoke(t *testing.T) {
-	b, s := getTestBackend(t, true)
 
 	t.Run("roles", func(t *testing.T) {
+		b, s := getTestBackend(t, true)
 		testRoleCreate(t, b, s, "test_role", testRole)
 
 		resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -267,6 +267,7 @@ func TestSPRevoke(t *testing.T) {
 	})
 
 	t.Run("groups", func(t *testing.T) {
+		b, s := getTestBackend(t, true)
 		testRoleCreate(t, b, s, "test_role", testGroupRole)
 
 		resp, err := b.HandleRequest(context.Background(), &logical.Request{


### PR DESCRIPTION
Note that we probably don't want to merge this to `master` and instead we should probably create a topic branch for Datadog specific changes.

This PR adds the `<mountPath>/token/<role>` endpoint to return an Oauth access token. This access token is **not** leased because these tokens have a TTL of 60m and are not revokable upstream. 

This PR does not make use of the oauth refresh token. Azure refresh tokens are valid for 24h so technically we could renew an access token for 24h but clients would need special logic to handle that so I'm not going to support that for now.

~~One important change is that I'm moving the App/ServicePrincipal creation for dynamic service principals into the `<mountPath>/roles/<role>` endpoint because we need to create these anyways if a static app is not being used. For both dynamic and static apps client credentials are created on Vault role creation. Additionally, callers may choose to call `<mountPath>/creds/<role>` which will actually create leased client credentials as the endpoint would do already.~~

Outstanding tasks:
1. ~~look through sections of code that may need locking~~
1. ~~probably should make use of the WAL~~
1. ~~add tests for new access token endpoint~~
1. ~~investigate bug where multiple client credentials could be added to a static app but when the Vault role is deleted the credentials are not revoked (these creds are leased though so they will expire out eventually).~~

**Update 6/22/2020:**

I've updated/rewritten this PR to not try to consolidate App/ServicePrincipals because there are some unknowns about what the original authors intended to do with this plugin. The dynamic ServicePrincipal functionality correctly creates the App and ServicePrincipal and creates a password on the ServicePrincipal. However, the plugin documentation states that passwords are created for "existing Service Principals" but that is not true, the password is created for the App and no ServicePrincipal is created. I started [a thread about this with the community here](https://groups.google.com/g/vault-tool/c/ZPugq2AI0aQ).

I've also noticed that when a Vault role is deleted, the Azure client credentials are not revoked. Instead, when the TTL on the lease expires the credentials will be revoked. However, the default TTL we use is 1month IIRC so this could end up leaking resources in Azure which is not great. see https://github.com/hashicorp/vault-plugin-secrets-azure/issues/41

Because of all this, I've opt'd not to try consolidating Apps/ServicePrincipals for Vault roles as mentioned above until there is more clarity around what should be created for static applications.