### PR TITLE
PROD-347: Fix bug with updating roles

### DIFF
--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -207,8 +207,9 @@ func TestStaticSPRead(t *testing.T) {
 		equal(t, 0*time.Second, resp.Secret.MaxTTL)
 
 		roleUpdate := map[string]interface{}{
-			"ttl":     20,
-			"max_ttl": 30,
+			"application_object_id": "00000000-0000-0000-0000-000000000000",
+			"ttl":                   20,
+			"max_ttl":               30,
 		}
 		testRoleCreate(t, b, s, name, roleUpdate)
 


### PR DESCRIPTION
On requests to update a role, the type would change from dynamic to
static resulting in cloud resources leaking.

This changes the role logic so that role types cannot be changed once
created (i.e. cannot change static to dynamic or dynamic to static).
