### PR TITLE
PROD-489: Fix dynamic ServicePrincipal Azure Group/Role updates

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -206,11 +206,11 @@ func (m *mockProvider) VMUpdate(ctx context.Context, resourceGroupName string, V
 
 func (m *mockProvider) CreateRoleAssignment(ctx context.Context, scope string, roleAssignmentName string, parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
 	return authorization.RoleAssignment{
-		ID: to.StringPtr(generateUUID()),
+		ID: to.StringPtr(fmt.Sprintf("00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT/%s", to.String(parameters.RoleDefinitionID))),
 	}, nil
 }
 
-func (m *mockProvider) DeleteRoleAssignmentByID(ctx context.Context, roleID string) (result authorization.RoleAssignment, err error) {
+func (m *mockProvider) DeleteRoleAssignmentByID(ctx context.Context, roleAssignmentID string) (result authorization.RoleAssignment, err error) {
 	return authorization.RoleAssignment{}, nil
 }
 

--- a/path_roles.go
+++ b/path_roles.go
@@ -55,6 +55,8 @@ type AzureRole struct {
 	RoleName string `json:"role_name"` // e.g. Owner
 	RoleID   string `json:"role_id"`   // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleDefinitions/de139f84-...
 	Scope    string `json:"scope"`     // e.g. /subscriptions/e0a207b2-...
+
+	RoleAssignmentID string `json:"role_assignment_id"` // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleAssignments/de139f84-...
 }
 
 // AzureGroup is an Azure Active Directory Group
@@ -381,7 +383,7 @@ func (b *azureSecretBackend) configureRoles(ctx context.Context, client *client,
 	rolesToAdd := roleSetDifference(requestedRoles, role.AzureRoles)
 	rolesToRemove := roleSetDifference(role.AzureRoles, requestedRoles)
 
-	err := client.assignRoles(ctx, role.ServicePrincipalID, rolesToAdd)
+	_, err := client.assignRoles(ctx, role.ServicePrincipalID, rolesToAdd)
 	if err != nil {
 		return err
 	}

--- a/path_roles.go
+++ b/path_roles.go
@@ -56,7 +56,7 @@ type AzureRole struct {
 	RoleID   string `json:"role_id"`   // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleDefinitions/de139f84-...
 	Scope    string `json:"scope"`     // e.g. /subscriptions/e0a207b2-...
 
-	RoleAssignmentID string `json:"role_assignment_id"` // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleAssignments/de139f84-...
+	RoleAssignmentID string `json:"role_assignment_id,omitempty"` // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleAssignments/de139f84-...
 }
 
 // AzureGroup is an Azure Active Directory Group
@@ -413,6 +413,9 @@ func (b *azureSecretBackend) pathRoleRead(ctx context.Context, req *logical.Requ
 
 	data["ttl"] = role.TTL / time.Second
 	data["max_ttl"] = role.MaxTTL / time.Second
+	for _, ar := range role.AzureRoles {
+		ar.RoleAssignmentID = ""
+	}
 	data["azure_roles"] = role.AzureRoles
 	data["azure_groups"] = role.AzureGroups
 	aoid := ""

--- a/path_roles.go
+++ b/path_roles.go
@@ -18,8 +18,12 @@ import (
 )
 
 const (
-	rolesStoragePath       = "roles"
-	applicationTypeStatic  = "static"
+	rolesStoragePath = "roles"
+
+	// applicationTypeStatic for when a role is configured with an application_object_id (i.e. the application is managed externally)
+	applicationTypeStatic = "static"
+
+	// applicationTypeDynamic for when a role is configured without an application_object_id
 	applicationTypeDynamic = "dynamic"
 
 	credentialTypeSP = 0
@@ -174,10 +178,12 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			return nil, errors.New("role entry not found during update operation")
 		}
 		role = &roleEntry{
-			CredentialType: credentialTypeSP,
+			ApplicationObjectID: appObjectID,
+			AzureGroups:         []*AzureGroup{},
+			AzureRoles:          []*AzureRole{},
+			CredentialType:      credentialTypeSP,
 		}
 
-		role.ApplicationObjectID = appObjectID
 		if role.ApplicationObjectID == "" {
 			role.ApplicationType = applicationTypeDynamic
 		} else {
@@ -209,6 +215,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 	}
 
 	// Parse the Azure roles
+	var requestedRoles []*AzureRole
 	if roles, ok := d.GetOk("azure_roles"); ok {
 		parsedRoles := make([]*AzureRole, 0) // non-nil to avoid a "missing roles" error later
 
@@ -216,10 +223,11 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		if err != nil {
 			return logical.ErrorResponse("error parsing Azure roles '%s': %s", roles.(string), err.Error()), nil
 		}
-		role.AzureRoles = parsedRoles
+		requestedRoles = parsedRoles
 	}
 
 	// Parse the Azure groups
+	var requestedGroups []*AzureGroup
 	if groups, ok := d.GetOk("azure_groups"); ok {
 		parsedGroups := make([]*AzureGroup, 0) // non-nil to avoid a "missing groups" error later
 
@@ -227,12 +235,12 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		if err != nil {
 			return logical.ErrorResponse("error parsing Azure groups '%s': %s", groups.(string), err.Error()), nil
 		}
-		role.AzureGroups = parsedGroups
+		requestedGroups = parsedGroups
 	}
 
 	// update and verify Azure roles, including looking up each role by ID or name.
 	roleSet := make(map[string]bool)
-	for _, r := range role.AzureRoles {
+	for _, r := range requestedRoles {
 		var roleDef authorization.RoleDefinition
 		if r.RoleID != "" {
 			roleDef, err = client.provider.GetRoleByID(ctx, r.RoleID)
@@ -269,7 +277,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 	// update and verify Azure groups, including looking up each group by ID or name.
 	groupSet := make(map[string]bool)
-	for _, r := range role.AzureGroups {
+	for _, r := range requestedGroups {
 		var groupDef graphrbac.ADGroup
 		if r.ObjectID != "" {
 			groupDef, err = client.provider.GetGroup(ctx, r.ObjectID)
@@ -302,7 +310,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		groupSet[r.ObjectID] = true
 	}
 
-	if role.ApplicationObjectID == "" && len(role.AzureRoles) == 0 && len(role.AzureGroups) == 0 {
+	if role.ApplicationObjectID == "" && len(requestedRoles) == 0 && len(requestedGroups) == 0 {
 		return logical.ErrorResponse("either Azure role definitions, group definitions, or an Application Object ID must be provided"), nil
 	}
 
@@ -314,19 +322,32 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		role.ApplicationID = to.String(app.AppID)
 	}
 
-	// Only add credentials if this is a new role or a role that existed before access token support was available
-	if role.Credentials == nil {
-		switch role.ApplicationType {
-		case applicationTypeStatic:
-			err = b.createStaticSPSecret(ctx, client, role)
-		case applicationTypeDynamic:
+	if role.ApplicationType == applicationTypeDynamic {
+		if role.Credentials == nil {
 			err = b.createSPSecret(ctx, client, role)
-		default:
-			return nil, fmt.Errorf("unknown role ApplicationType \"%v\"", role.ApplicationType)
+			if err != nil {
+				return nil, err
+			}
 		}
+
+		err = b.configureRoles(ctx, client, role, requestedRoles)
 		if err != nil {
 			return nil, err
 		}
+
+		err = b.configureGroups(ctx, client, role, requestedGroups)
+		if err != nil {
+			return nil, err
+		}
+	} else if role.ApplicationType == applicationTypeStatic {
+		if role.Credentials == nil {
+			err = b.createStaticSPSecret(ctx, client, role)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("unknown role ApplicationType \"%v\"", role.ApplicationType)
 	}
 
 	// save role
@@ -336,6 +357,42 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 	}
 
 	return resp, nil
+}
+
+func (b *azureSecretBackend) configureGroups(ctx context.Context, client *client, role *roleEntry, requestedGroups []*AzureGroup) error {
+	groupsToAdd := groupSetDifference(requestedGroups, role.AzureGroups)
+	groupsToRemove := groupSetDifference(role.AzureGroups, requestedGroups)
+
+	err := client.addGroupMemberships(ctx, role.ServicePrincipalID, groupsToAdd)
+	if err != nil {
+		return err
+	}
+
+	err = client.removeGroupMemberships(ctx, role.ServicePrincipalID, groupsToRemove)
+	if err != nil {
+		return err
+	}
+
+	role.AzureGroups = requestedGroups
+	return nil
+}
+
+func (b *azureSecretBackend) configureRoles(ctx context.Context, client *client, role *roleEntry, requestedRoles []*AzureRole) error {
+	rolesToAdd := roleSetDifference(requestedRoles, role.AzureRoles)
+	rolesToRemove := roleSetDifference(role.AzureRoles, requestedRoles)
+
+	err := client.assignRoles(ctx, role.ServicePrincipalID, rolesToAdd)
+	if err != nil {
+		return err
+	}
+
+	err = client.unassignRoles(ctx, rolesToRemove)
+	if err != nil {
+		return err
+	}
+
+	role.AzureRoles = requestedRoles
+	return nil
 }
 
 func (b *azureSecretBackend) pathRoleRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -450,6 +507,40 @@ func getRole(ctx context.Context, name string, s logical.Storage) (*roleEntry, e
 		return nil, err
 	}
 	return role, nil
+}
+
+func groupSetDifference(a []*AzureGroup, b []*AzureGroup) []*AzureGroup {
+	difference := []*AzureGroup{}
+
+	m := make(map[AzureGroup]bool)
+	for _, bVal := range b {
+		m[*bVal] = true
+	}
+
+	for _, aVal := range a {
+		if _, ok := m[*aVal]; !ok {
+			difference = append(difference, aVal)
+		}
+	}
+
+	return difference
+}
+
+func roleSetDifference(a []*AzureRole, b []*AzureRole) []*AzureRole {
+	difference := []*AzureRole{}
+
+	m := make(map[AzureRole]bool)
+	for _, bVal := range b {
+		m[*bVal] = true
+	}
+
+	for _, aVal := range a {
+		if _, ok := m[*aVal]; !ok {
+			difference = append(difference, aVal)
+		}
+	}
+
+	return difference
 }
 
 const roleHelpSyn = "Manage the Vault roles used to generate Azure credentials."

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -21,14 +21,12 @@ func TestRoleCreate(t *testing.T) {
 		{
 			"role_name": "Owner",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-			"scope":  "test_scope_1",
-			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
+			"scope":  "test_scope_1"
 		},
 		{
 			"role_name": "Owner2",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2",
-			"scope":  "test_scope_2",
-			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2"
+			"scope":  "test_scope_2"
 		}]`),
 			"azure_groups": compactJSON(`[
 		{
@@ -49,14 +47,12 @@ func TestRoleCreate(t *testing.T) {
 		{
 			"role_name": "Contributor",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-			"scope":  "test_scope_3",
-			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
+			"scope":  "test_scope_3"
 		},
 		{
 			"role_name": "Contributor2",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor2",
-			"scope":  "test_scope_3",
-			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor2"
+			"scope":  "test_scope_3"
 		}]`),
 			"azure_groups": compactJSON(`[
 		{
@@ -153,8 +149,7 @@ func TestRoleCreate(t *testing.T) {
 				{
 					"role_name": "Contributor",
 					"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-					"scope":  "test_scope_3",
-					"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
+					"scope":  "test_scope_3"
 				}]`,
 			),
 			"azure_groups":          "[]",
@@ -235,8 +230,7 @@ func TestRoleCreate(t *testing.T) {
 				{
 					"role_name": "Contributor",
 					"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-					"scope":  "test_scope_3",
-					"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
+					"scope":  "test_scope_3"
 				}]`,
 			),
 			"application_object_id": "",
@@ -569,14 +563,12 @@ func TestRoleUpdate(t *testing.T) {
 			"azure_roles": compactJSON(`[{
 				"role_name": "Owner",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-				"scope":  "test_scope_1",
-				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
+				"scope":  "test_scope_1"
 			},
 			{
 				"role_name": "Owner2",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2",
-				"scope":  "test_scope_2",
-				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2"
+				"scope":  "test_scope_2"
 			}]`),
 			"azure_groups": compactJSON(`[{
 				"group_name": "foo",
@@ -607,8 +599,7 @@ func TestRoleUpdate(t *testing.T) {
 			"azure_roles": compactJSON(`[{
 				"role_name": "Owner",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-				"scope":  "test_scope_1",
-				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
+				"scope":  "test_scope_1"
 			}]`),
 			"azure_groups": compactJSON(`[{
 				"group_name": "foo",

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -21,12 +21,14 @@ func TestRoleCreate(t *testing.T) {
 		{
 			"role_name": "Owner",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-			"scope":  "test_scope_1"
+			"scope":  "test_scope_1",
+			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
 		},
 		{
 			"role_name": "Owner2",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2",
-			"scope":  "test_scope_2"
+			"scope":  "test_scope_2",
+			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2"
 		}]`),
 			"azure_groups": compactJSON(`[
 		{
@@ -47,12 +49,14 @@ func TestRoleCreate(t *testing.T) {
 		{
 			"role_name": "Contributor",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-			"scope":  "test_scope_3"
+			"scope":  "test_scope_3",
+			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
 		},
 		{
 			"role_name": "Contributor2",
 			"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor2",
-			"scope":  "test_scope_3"
+			"scope":  "test_scope_3",
+			"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor2"
 		}]`),
 			"azure_groups": compactJSON(`[
 		{
@@ -149,7 +153,8 @@ func TestRoleCreate(t *testing.T) {
 				{
 					"role_name": "Contributor",
 					"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-					"scope":  "test_scope_3"
+					"scope":  "test_scope_3",
+					"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
 				}]`,
 			),
 			"azure_groups":          "[]",
@@ -230,7 +235,8 @@ func TestRoleCreate(t *testing.T) {
 				{
 					"role_name": "Contributor",
 					"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
-					"scope":  "test_scope_3"
+					"scope":  "test_scope_3",
+					"role_assignment_id":"00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor"
 				}]`,
 			),
 			"application_object_id": "",
@@ -563,12 +569,14 @@ func TestRoleUpdate(t *testing.T) {
 			"azure_roles": compactJSON(`[{
 				"role_name": "Owner",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-				"scope":  "test_scope_1"
+				"scope":  "test_scope_1",
+				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
 			},
 			{
 				"role_name": "Owner2",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2",
-				"scope":  "test_scope_2"
+				"scope":  "test_scope_2",
+				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner2"
 			}]`),
 			"azure_groups": compactJSON(`[{
 				"group_name": "foo",
@@ -599,7 +607,8 @@ func TestRoleUpdate(t *testing.T) {
 			"azure_roles": compactJSON(`[{
 				"role_name": "Owner",
 				"role_id": "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
-				"scope":  "test_scope_1"
+				"scope":  "test_scope_1",
+				"role_assignment_id": "00000000-1111-2222-3333-444444444444FAKE_ROLE_ASSIGNMENT//subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner"
 			}]`),
 			"azure_groups": compactJSON(`[{
 				"group_name": "foo",

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -75,19 +75,31 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 	}
 
 	var secretType string
-	switch role.ApplicationType {
-	case applicationTypeStatic:
-		err = b.createStaticSPSecret(ctx, client, role)
-		secretType = SecretTypeStaticSP
-	case applicationTypeDynamic:
-		err = b.createSPSecret(ctx, client, role)
+	var raIDs []string
+	if role.ApplicationType == applicationTypeDynamic {
 		secretType = SecretTypeSP
-	default:
-		return nil, fmt.Errorf("unknown role ApplicationType \"%v\"", role.ApplicationType)
-	}
+		err = b.createSPSecret(ctx, client, role)
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return nil, err
+		raIDs, err = client.assignRoles(ctx, role.ServicePrincipalID, role.AzureRoles)
+		if err != nil {
+			return nil, err
+		}
+
+		err := client.addGroupMemberships(ctx, role.ServicePrincipalID, role.AzureGroups)
+		if err != nil {
+			return nil, err
+		}
+	} else if role.ApplicationType == applicationTypeStatic {
+		secretType = SecretTypeStaticSP
+		err = b.createStaticSPSecret(ctx, client, role)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("unknown role ApplicationType \"%v\"", role.ApplicationType)
 	}
 
 	data := map[string]interface{}{
@@ -98,7 +110,7 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 		"app_object_id":        role.ApplicationObjectID,
 		"key_id":               role.Credentials.KeyId,
 		"sp_object_id":         role.ServicePrincipalID,
-		"role_assignment_ids":  roleIDs(role.AzureRoles),
+		"role_assignment_ids":  raIDs,
 		"group_membership_ids": groupObjectIDs(role.AzureGroups),
 		"role":                 roleName,
 	}
@@ -197,7 +209,7 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 	if req.Secret.InternalData["role_assignment_ids"] != nil {
 		for _, v := range req.Secret.InternalData["role_assignment_ids"].([]interface{}) {
 			roles = append(roles, &AzureRole{
-				RoleID: v.(string),
+				RoleAssignmentID: v.(string),
 			})
 		}
 	}
@@ -242,7 +254,7 @@ func (b *azureSecretBackend) spRemove(ctx context.Context, req *logical.Request,
 	// operation. Errors will be noted but won't fail the revocation process.
 	// Deleting the app, however, *is* required to consider the secret revoked.
 	if err := c.removeGroupMemberships(ctx, role.ServicePrincipalID, role.AzureGroups); err != nil {
-		resp.AddWarning(err.Error())
+		return nil, err
 	}
 
 	err = c.deleteApp(ctx, role.ApplicationObjectID)

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -127,18 +127,6 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 		return err
 	}
 
-	// Assign Azure roles to the new SP
-	if _, err = c.assignRoles(ctx, sp, role.AzureRoles); err != nil {
-		c.deleteApp(ctx, appObjID)
-		return err
-	}
-
-	// Assign Azure group memberships to the new SP
-	if err = c.addGroupMemberships(ctx, sp, role.AzureGroups); err != nil {
-		c.deleteApp(ctx, appObjID)
-		return err
-	}
-
 	role.ApplicationID = appID
 	role.ApplicationObjectID = appObjID
 	role.ServicePrincipalID = to.String(sp.ObjectID)
@@ -246,14 +234,14 @@ func (b *azureSecretBackend) spRemove(ctx context.Context, req *logical.Request,
 	resp := new(logical.Response)
 	// unassigning roles is effectively a garbage collection operation. Errors will be noted but won't fail the
 	// revocation process. Deleting the app, however, *is* required to consider the secret revoked.
-	if err := c.unassignRoles(ctx, roleIDs(role.AzureRoles)); err != nil {
+	if err := c.unassignRoles(ctx, role.AzureRoles); err != nil {
 		resp.AddWarning(err.Error())
 	}
 
 	// removing group membership is effectively a garbage collection
 	// operation. Errors will be noted but won't fail the revocation process.
 	// Deleting the app, however, *is* required to consider the secret revoked.
-	if err := c.removeGroupMemberships(ctx, role.ServicePrincipalID, groupObjectIDs(role.AzureGroups)); err != nil {
+	if err := c.removeGroupMemberships(ctx, role.ServicePrincipalID, role.AzureGroups); err != nil {
 		resp.AddWarning(err.Error())
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -52,7 +52,7 @@ type RoleAssignmentsClient interface {
 		scope string,
 		roleAssignmentName string,
 		parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error)
-	DeleteRoleAssignmentByID(ctx context.Context, roleID string) (authorization.RoleAssignment, error)
+	DeleteRoleAssignmentByID(ctx context.Context, roleAssignmentID string) (authorization.RoleAssignment, error)
 }
 
 type RoleDefinitionsClient interface {


### PR DESCRIPTION
Prior to this commit, an update to a Vault role would that include a
change to the Azure groups or roles would not actually update the group
membership/role assignment of the ServicePrincipal.
