### PR TITLE
PROD-487: Update ServicePrincipal WAL cleanup logic based on forked changes

### DIFF
--- a/path_roles.go
+++ b/path_roles.go
@@ -326,9 +326,14 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 	if role.ApplicationType == applicationTypeDynamic {
 		if role.Credentials == nil {
-			err = b.createSPSecret(ctx, req.Storage, client, role)
+			walID, err := b.createSPSecret(ctx, req.Storage, client, role)
 			if err != nil {
 				return nil, err
+			}
+
+			// SP is fully created so delete the WAL
+			if err := framework.DeleteWAL(ctx, req.Storage, walID); err != nil {
+				return nil, errwrap.Wrapf("error deleting WAL: {{err}}", err)
 			}
 		}
 


### PR DESCRIPTION
This PR keeps the existing WAL logic introduced upstream. There are considerations being made for re-implementing this oauth access token endpoint which will address the following concerns:

- leaking of RoleAssignments during App/ServicePrincipal provisioning for both `creds` and `roles` endpoints
- inconsistent identity across all credentials generated from a given Vault role (making auditing harder)
- excessive creation of App/ServicePrincipals
- Inability to revoke all Azure credentials for a given Vault role upon role deletion

In addition to the above, re-implementing this should involve storing an App/ServicePrincipal for each Vault role when it is created instead of creating new resources whenever the `creds` endpoint is called. This should consolidate/simplify the logic of the plugin, hopefully reducing the LoC.