### PR TITLE
PROD-599: Add debug logging for creating access tokens

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -31,7 +31,11 @@ const (
 )
 
 func getTestBackend(t *testing.T, initConfig bool) (*azureSecretBackend, logical.Storage) {
-	b := backend()
+	b := backend(
+		&logical.BackendConfig{
+			StorageView: &logical.InmemStorage{},
+		},
+	)
 
 	config := &logical.BackendConfig{
 		Logger: logging.NewVaultLogger(log.Trace),

--- a/path_access_token.go
+++ b/path_access_token.go
@@ -70,6 +70,16 @@ func (b *azureSecretBackend) secretAccessTokenResponse(ctx context.Context, stor
 		return nil, err
 	}
 
+	if b.Logger().IsDebug() {
+		nacl, err := b.Salt(ctx)
+		if err != nil {
+			b.Logger().Error("error creating access token", "error", err)
+		}
+		hmac := nacl.GetIdentifiedHMAC(role.Credentials.Password)
+		b.Logger().Debug("retrieving Azure access token for application ID",
+			"client_id", role.ApplicationID, "client_secret", hmac, "key_id", role.Credentials.KeyId)
+	}
+
 	cc := azureauth.NewClientCredentialsConfig(role.ApplicationID, role.Credentials.Password, client.settings.TenantID)
 	cc.Resource = resource
 	token, err := b.getToken(ctx, client, cc)

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -496,7 +496,11 @@ func TestCredentialInteg(t *testing.T) {
 	t.Run("SP", func(t *testing.T) {
 		t.Parallel()
 
-		b := backend()
+		b := backend(
+			&logical.BackendConfig{
+				StorageView: &logical.InmemStorage{},
+			},
+		)
 		s := new(logical.InmemStorage)
 		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 
@@ -631,7 +635,11 @@ func TestCredentialInteg(t *testing.T) {
 	t.Run("Static SP", func(t *testing.T) {
 		t.Parallel()
 
-		b := backend()
+		b := backend(
+			&logical.BackendConfig{
+				StorageView: &logical.InmemStorage{},
+			},
+		)
 		s := new(logical.InmemStorage)
 
 		config := &logical.BackendConfig{


### PR DESCRIPTION
Prints DEBUG log message with the application ID, key ID, and hmac(password) to help in isolating why Azure client credentials are invalid when trying to create an access token for a static application.