### PR TITLE
PROD-599: Use the MS Graph API for atomic add/remove password operations

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -19,7 +19,7 @@ type azureSecretBackend struct {
 	salt      *salt.Salt
 	saltMutex sync.RWMutex
 
-	getProvider func(*clientSettings) (AzureProvider, error)
+	getProvider func(*clientSettings, bool, passwords) (AzureProvider, error)
 	client      *client
 	settings    *clientSettings
 	lock        sync.RWMutex
@@ -155,14 +155,14 @@ func (b *azureSecretBackend) getClient(ctx context.Context, s logical.Storage) (
 		b.settings = settings
 	}
 
-	p, err := b.getProvider(b.settings)
-	if err != nil {
-		return nil, err
-	}
-
 	passwords := passwords{
 		policyGenerator: b.System(),
 		policyName:      config.PasswordPolicy,
+	}
+
+	p, err := b.getProvider(b.settings, config.UseMsGraphAPI, passwords)
+	if err != nil {
+		return nil, err
 	}
 
 	c := &client{

--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func (c *client) Valid() bool {
 // createApp creates a new Azure application.
 // An Application is a needed to create service principals used by
 // the caller for authentication.
-func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err error) {
+func (c *client) createApp(ctx context.Context) (app *ApplicationResult, err error) {
 	name, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, err
@@ -52,14 +52,7 @@ func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err
 
 	name = appNamePrefix + name
 
-	appURL := fmt.Sprintf("https://%s", name)
-
-	result, err := c.provider.CreateApplication(ctx, graphrbac.ApplicationCreateParameters{
-		AvailableToOtherTenants: to.BoolPtr(false),
-		DisplayName:             to.StringPtr(name),
-		Homepage:                to.StringPtr(appURL),
-		IdentifierUris:          to.StringSlicePtr([]string{appURL}),
-	})
+	result, err := c.provider.CreateApplication(ctx, name)
 
 	return &result, err
 }
@@ -67,7 +60,7 @@ func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err
 // createSP creates a new service principal.
 func (c *client) createSP(
 	ctx context.Context,
-	app *graphrbac.Application,
+	app *ApplicationResult,
 	duration time.Duration) (svcPrinc *graphrbac.ServicePrincipal, password string, err error) {
 
 	// Generate a random key (which must be a UUID) and password

--- a/client.go
+++ b/client.go
@@ -114,85 +114,26 @@ func (c *client) createSP(
 }
 
 // addAppPassword adds a new password to an App's credentials list.
-func (c *client) addAppPassword(ctx context.Context, appObjID string, duration time.Duration) (keyID string, password string, err error) {
-	keyID, err = uuid.GenerateUUID()
+func (c *client) addAppPassword(ctx context.Context, appObjID string, expiresIn time.Duration) (string, string, error) {
+	exp := date.Time{Time: time.Now().Add(expiresIn)}
+	resp, err := c.provider.AddApplicationPassword(ctx, appObjID, "vault-plugin-secrets-azure", exp)
 	if err != nil {
-		return "", "", err
-	}
-
-	// Key IDs are not secret, and they're a convenient way for an operator to identify Vault-generated
-	// passwords. These must be UUIDs, so the three leading bytes will be used as an indicator.
-	keyID = "ffffff" + keyID[6:]
-
-	password, err = c.passwords.generate(ctx)
-	if err != nil {
-		return "", "", err
-	}
-
-	now := time.Now().UTC()
-	cred := graphrbac.PasswordCredential{
-		StartDate: &date.Time{Time: now},
-		EndDate:   &date.Time{Time: now.Add(duration)},
-		KeyID:     to.StringPtr(keyID),
-		Value:     to.StringPtr(password),
-	}
-
-	// Load current credentials
-	resp, err := c.provider.ListApplicationPasswordCredentials(ctx, appObjID)
-	if err != nil {
-		return "", "", errwrap.Wrapf("error fetching credentials: {{err}}", err)
-	}
-	curCreds := *resp.Value
-
-	// Add and save credentials
-	curCreds = append(curCreds, cred)
-
-	if _, err := c.provider.UpdateApplicationPasswordCredentials(ctx, appObjID,
-		graphrbac.PasswordCredentialsUpdateParameters{
-			Value: &curCreds,
-		},
-	); err != nil {
 		if strings.Contains(err.Error(), "size of the object has exceeded its limit") {
 			err = errors.New("maximum number of Application passwords reached")
 		}
 		return "", "", errwrap.Wrapf("error updating credentials: {{err}}", err)
 	}
 
-	return keyID, password, nil
+	return to.String(resp.KeyID), to.String(resp.SecretText), nil
 }
 
 // deleteAppPassword removes a password, if present, from an App's credentials list.
 func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) error {
-	// Load current credentials
-	resp, err := c.provider.ListApplicationPasswordCredentials(ctx, appObjID)
-	if err != nil {
-		return errwrap.Wrapf("error fetching credentials: {{err}}", err)
-	}
-	curCreds := *resp.Value
-
-	// Remove credential
-	found := false
-	for i := range curCreds {
-		if to.String(curCreds[i].KeyID) == keyID {
-			curCreds[i] = curCreds[len(curCreds)-1]
-			curCreds = curCreds[:len(curCreds)-1]
-			found = true
-			break
+	if _, err := c.provider.RemoveApplicationPassword(ctx, appObjID, keyID); err != nil {
+		if strings.Contains(err.Error(), "No password credential found with keyId") {
+			return nil
 		}
-	}
-
-	// KeyID is not present, so nothing to do
-	if !found {
-		return nil
-	}
-
-	// Save new credentials list
-	if _, err := c.provider.UpdateApplicationPasswordCredentials(ctx, appObjID,
-		graphrbac.PasswordCredentialsUpdateParameters{
-			Value: &curCreds,
-		},
-	); err != nil {
-		return errwrap.Wrapf("error updating credentials: {{err}}", err)
+		return errwrap.Wrapf("error removing credentials: {{err}}", err)
 	}
 
 	return nil

--- a/graph_api_client.go
+++ b/graph_api_client.go
@@ -255,7 +255,7 @@ func (client MSGraphApplicationClient) createApplicationPreparer(ctx context.Con
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPost(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPath("/v1.0/applications/{applicationObjectId}"),
+		autorest.WithPath("/v1.0/applications"),
 		autorest.WithJSON(parameters),
 		client.Authorizer.WithAuthorization())
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -270,7 +270,7 @@ func (client MSGraphApplicationClient) createApplicationResponder(resp *http.Res
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		azure.WithErrorUnlessStatusCode(http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}

--- a/graph_api_client.go
+++ b/graph_api_client.go
@@ -1,0 +1,120 @@
+package azuresecrets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const (
+	// defaultGraphMicrosoftComURI is the default URI used for the service MS Graph API
+	defaultGraphMicrosoftComURI = "https://graph.microsoft.com"
+)
+
+type MSGraphApplicationClient struct {
+	authorization.BaseClient
+}
+
+func newMSGraphApplicationClient(subscriptionId string) MSGraphApplicationClient {
+	return MSGraphApplicationClient{authorization.NewWithBaseURI(defaultGraphMicrosoftComURI, subscriptionId)}
+}
+
+func (client MSGraphApplicationClient) addPasswordPreparer(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	parameters := struct {
+		PasswordCredential *passwordCredential `json:"passwordCredential"`
+	}{
+		PasswordCredential: &passwordCredential{
+			DisplayName: to.StringPtr(displayName),
+			EndDate:     &endDateTime,
+		},
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}/addPassword", pathParameters),
+		autorest.WithJSON(parameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client MSGraphApplicationClient) addPasswordSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client MSGraphApplicationClient) addPasswordResponder(resp *http.Response) (result PasswordCredentialResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+func (client MSGraphApplicationClient) removePasswordPreparer(ctx context.Context, applicationObjectID string, keyID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	parameters := struct {
+		KeyID string `json:"keyId"`
+	}{
+		KeyID: keyID,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}/removePassword", pathParameters),
+		autorest.WithJSON(parameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client MSGraphApplicationClient) removePasswordSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client MSGraphApplicationClient) removePasswordResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+type passwordCredential struct {
+	DisplayName *string `json:"displayName"`
+	// StartDate - Start date.
+	StartDate *date.Time `json:"startDateTime,omitempty"`
+	// EndDate - End date.
+	EndDate *date.Time `json:"endDateTime,omitempty"`
+	// KeyID - Key ID.
+	KeyID *string `json:"keyId,omitempty"`
+	// Value - Key value.
+	SecretText *string `json:"secretText,omitempty"`
+}
+
+type PasswordCredentialResult struct {
+	autorest.Response `json:"-"`
+
+	passwordCredential
+}

--- a/path_config.go
+++ b/path_config.go
@@ -24,6 +24,7 @@ type azureConfig struct {
 	ClientSecret   string `json:"client_secret"`
 	Environment    string `json:"environment"`
 	PasswordPolicy string `json:"password_policy"`
+	UseMsGraphAPI  bool   `json:"use_microsoft_graph_api"`
 }
 
 func pathConfig(b *azureSecretBackend) *framework.Path {
@@ -58,6 +59,10 @@ func pathConfig(b *azureSecretBackend) *framework.Path {
 			"password_policy": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Name of the password policy to use to generate passwords for dynamic credentials.",
+			},
+			"use_microsoft_graph_api": &framework.FieldSchema{
+				Type:        framework.TypeBool,
+				Description: "Enable usage of the Microsoft Graph API over the deprecated Azure AD Graph API.",
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -120,6 +125,10 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 		config.ClientSecret = clientSecret.(string)
 	}
 
+	if useMsGraphApi, ok := data.GetOk("use_microsoft_graph_api"); ok {
+		config.UseMsGraphAPI = useMsGraphApi.(bool)
+	}
+
 	config.PasswordPolicy = data.Get("password_policy").(string)
 
 	if merr.ErrorOrNil() != nil {
@@ -144,10 +153,11 @@ func (b *azureSecretBackend) pathConfigRead(ctx context.Context, req *logical.Re
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"subscription_id": config.SubscriptionID,
-			"tenant_id":       config.TenantID,
-			"environment":     config.Environment,
-			"client_id":       config.ClientID,
+			"subscription_id":         config.SubscriptionID,
+			"tenant_id":               config.TenantID,
+			"environment":             config.Environment,
+			"client_id":               config.ClientID,
+			"use_microsoft_graph_api": config.UseMsGraphAPI,
 		},
 	}
 	return resp, nil

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -12,11 +12,12 @@ func TestConfig(t *testing.T) {
 
 	// Test valid config
 	config := map[string]interface{}{
-		"subscription_id": "a228ceec-bf1a-4411-9f95-39678d8cdb34",
-		"tenant_id":       "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
-		"client_id":       "testClientId",
-		"client_secret":   "testClientSecret",
-		"environment":     "AZURECHINACLOUD",
+		"subscription_id":         "a228ceec-bf1a-4411-9f95-39678d8cdb34",
+		"tenant_id":               "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
+		"client_id":               "testClientId",
+		"client_secret":           "testClientSecret",
+		"environment":             "AZURECHINACLOUD",
+		"use_microsoft_graph_api": false,
 	}
 
 	testConfigCreate(t, b, s, config)
@@ -54,11 +55,12 @@ func TestConfigDelete(t *testing.T) {
 
 	// Test valid config
 	config := map[string]interface{}{
-		"subscription_id": "a228ceec-bf1a-4411-9f95-39678d8cdb34",
-		"tenant_id":       "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
-		"client_id":       "testClientId",
-		"client_secret":   "testClientSecret",
-		"environment":     "AZURECHINACLOUD",
+		"subscription_id":         "a228ceec-bf1a-4411-9f95-39678d8cdb34",
+		"tenant_id":               "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
+		"client_id":               "testClientId",
+		"client_secret":           "testClientSecret",
+		"environment":             "AZURECHINACLOUD",
+		"use_microsoft_graph_api": false,
 	}
 
 	testConfigCreate(t, b, s, config)
@@ -79,10 +81,11 @@ func TestConfigDelete(t *testing.T) {
 	}
 
 	config = map[string]interface{}{
-		"subscription_id": "",
-		"tenant_id":       "",
-		"client_id":       "",
-		"environment":     "",
+		"subscription_id":         "",
+		"tenant_id":               "",
+		"client_id":               "",
+		"environment":             "",
+		"use_microsoft_graph_api": false,
 	}
 	testConfigRead(t, b, s, config)
 }

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -135,7 +135,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 		return "", err
 	}
 	appID := to.String(app.AppID)
-	appObjID := to.String(app.ObjectID)
+	appObjID := to.String(app.ID)
 
 	// Write a WAL entry in case the SP create process doesn't complete
 	walID, err := framework.PutWAL(ctx, s, walAppKey, &walApp{

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -271,8 +271,8 @@ func TestStaticSPRead(t *testing.T) {
 		assertErrorIsNil(t, err)
 
 		keyID := resp.Secret.InternalData["key_id"].(string)
-		if !strings.HasPrefix(keyID, "ffffff") {
-			t.Fatalf("expected prefix 'ffffff': %s", keyID)
+		if len(keyID) == 0 {
+			t.Fatalf("expected keyId to not be empty")
 		}
 
 		client, err := b.getClient(context.Background(), s)
@@ -415,8 +415,8 @@ func TestStaticSPRevoke(t *testing.T) {
 	assertErrorIsNil(t, err)
 
 	keyID := resp.Secret.InternalData["key_id"].(string)
-	if !strings.HasPrefix(keyID, "ffffff") {
-		t.Fatalf("expected prefix 'ffffff': %s", keyID)
+	if len(keyID) == 0 {
+		t.Fatalf("expected keyId to not be empty")
 	}
 
 	client, err := b.getClient(context.Background(), s)

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -59,7 +59,7 @@ func TestSP_WAL_Cleanup(t *testing.T) {
 
 	// overwrite the normal test backend provider with the errMockProvider
 	errMockProvider := newErrMockProvider()
-	b.getProvider = func(s *clientSettings) (AzureProvider, error) {
+	b.getProvider = func(s *clientSettings, usMsGraphApi bool, p passwords) (AzureProvider, error) {
 		return errMockProvider, nil
 	}
 
@@ -743,7 +743,7 @@ func TestCredentialInteg(t *testing.T) {
 		for i := 0; i < 8; i++ {
 			// New credentials are only tested during an actual operation, not provider creation.
 			// This step should never fail.
-			p, err := newAzureProvider(settings)
+			p, err := newAzureProvider(settings, true, passwords{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Azure Active Directory Graph API has been deprecated and does not
provide support for atomically creating/removing passwords on an
application. As a result, there is a race conditions that can occur when
creds are being created for a static application that is configured on
multiple mounts or across multiple Vault clusters.

Additionally, although using the MS Graph API is a net benefit, it
itself has reliability issues when handling multiple requests in
parallel. More details can be found in
https://github.com/mdgreenfield/microsoft-graph-api-reliability